### PR TITLE
Remove expression wrapper in if statement

### DIFF
--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   do-not-merge:
-    if: ${{ contains(github.event.*.labels.*.name, 'do not merge') }}
+    if: contains(github.event.*.labels.*.name, 'do not merge')
     name: Check Do Not Merge
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Describe your changes

if statements do not need the wrapper. From [the docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif):

> When you use expressions in an if conditional, you may omit the expression syntax (${{ }}) because GitHub automatically evaluates the if conditional as an expression. For more information, see "Expressions."

